### PR TITLE
Improve robustness of FFMPEG installation in CI pipeline

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -18,7 +18,10 @@ jobs:
       - name: Install ffmpeg
         run: |
           apt-get update && \
-          apt-get install -y ffmpeg
+          until apt-get install -y ffmpeg; do \
+            echo "Retrying ffmpeg installation..."; \
+            sleep 5; \
+          done
 
       - name: Install dependencies
         run: |
@@ -71,7 +74,10 @@ jobs:
       - name: Install ffmpeg
         run: |
           apt-get update && \
-          apt-get install -y ffmpeg
+          until apt-get install -y ffmpeg; do \
+            echo "Retrying ffmpeg installation..."; \
+            sleep 5; \
+          done
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This PR adds a retry loop to the FFMPEG installation step in the CI workflow to handle network errors during installation.

A common error observed across multiple runs is:
  `E: Failed to fetch ... Error reading from server - read (104: Connection reset by peer)`

This PR eliminates the need to manually re-run the workflow when this error occurs.

### Key changes:
- Added a retry loop to the FFMPEG installation step in the CI workflow to ensure FFMPEG is always installed.
