### PR TITLE
Fix typos and update venv installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Follow these steps to create a virtual environment and install this package:
 3. Create a virtual environment in the project directory:
     - Unix/macOS:
         ```bash
-        python3 -m venv venv
+        python3 -m venv .venv
         ```
     - Windows:
         ```cmd

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Follow these steps to create a virtual environment and install this package:
 > ```
 
 ## Usage
-The example scripts [`lti_dd_mpc_example.py`](examples/lti_control/lti_dd_mpc_example.py) and [`nonlinear_dd_mpc_example.py`](examples/nonlinear_control/nonlinear_dd_mpc_example.py)demonstrate the setup, simulation, and data visualization of the Data-Driven MPC controllers applied to LTI and Nonlinear systems, respectively.
+The example scripts [`lti_dd_mpc_example.py`](examples/lti_control/lti_dd_mpc_example.py) and [`nonlinear_dd_mpc_example.py`](examples/nonlinear_control/nonlinear_dd_mpc_example.py) demonstrate the setup, simulation, and data visualization of the Data-Driven MPC controllers applied to LTI and Nonlinear systems, respectively.
 
 To run the example scripts, use the following commands:
 

--- a/direct_data_driven_mpc/lti_data_driven_mpc_controller.py
+++ b/direct_data_driven_mpc/lti_data_driven_mpc_controller.py
@@ -556,7 +556,7 @@ class LTIDataDrivenMPCController:
             input-output pair (`u_s`, `y_s`) in any minimal realization (last
             `n` input-output predictions, as considered in [1]). Defined by
             Equations (3d) (Nominal) and (6c) (Robust).
-        - **Input**: Constraints the predicted input (`ubar`). Defined by
+        - **Input**: Constrains the predicted input (`ubar`). Defined by
             Equation (6c).
         - **Slack Variable**: Bounds a slack variable that accounts
             for noisy online measurements and for noisy data used for

--- a/direct_data_driven_mpc/nonlinear_data_driven_mpc_controller.py
+++ b/direct_data_driven_mpc/nonlinear_data_driven_mpc_controller.py
@@ -823,7 +823,7 @@ class NonlinearDataDrivenMPCController:
             input-output equilibrium pair (predicted equilibrium setpoints
             `u_s`, `y_s`) in any minimal realization (last `n` input-output
             predictions, as considered in [2]). Defined by Equation (22d).
-        - **Input**: Constraints both the equilibrium input (predicted input
+        - **Input**: Constrains both the equilibrium input (predicted input
             setpoint `u_s`) and the input trajectory (`ubar`). Defined by
             Equation (22e).
 
@@ -946,8 +946,8 @@ class NonlinearDataDrivenMPCController:
         References:
             [2]: See class-level docstring for full reference details.
         """
-        # Define terminal state constraints for Nominal and Robust MPC
-        # based on Equation (3d) and Equation (6c) of [2], respectively.
+        # Define terminal state constraints for the
+        # Nonlinear MPC based on Equation (22d) of [2]
         terminal_constraints = [
             cp.vstack([self.ubar_terminal, self.ybar_terminal])
             == cp.vstack(


### PR DESCRIPTION
This PR fixes typos in `README.md` and controller docstrings. Additionally, it updates the virtual environment installation instructions for Unix/macOS in `README.md` to align with the standard `.venv` naming convention.

### Key changes:
- Fixed typos in `README.md` and controller docstrings (`lti_data_driven_mpc_controller.py`, `nonlinear_data_driven_mpc_controller.py`).
- Updated the virtual environment installation instructions for Unix/macOS in `README.md` to use `.venv` instead of `venv`.
