### PR TITLE
Fix virtual env activation instruction in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Follow these steps to create a virtual environment and install this package:
 4. Activate the virtual environment:
     - Unix/macOS:
         ```bash
-        source venv/bin/activate
+        source .venv/bin/activate
         ```
     - Windows:
         ```cmd


### PR DESCRIPTION
This PR fixes the virtual environment activation instructions in `README.md` to align with the virtual environment creation instructions, which use `.venv` for Unix/macOS.

### Key changes:
- Replaced `venv/` with `.venv/` in the virtual environment activation instruction for Unix/macOS in `README.md`.
