### PR TITLE
Add workflows for release and main branch testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,145 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+env:
+  PACKAGE_NAME: "direct-data-driven-mpc"
+  TAG_NAME: ${{ github.ref_name }}
+  PYTHON_VERSION: '3.12'
+
+jobs:
+  verify_tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag matches pyproject.toml version
+        id: release
+        run: |
+          TAG_VERSION=$TAG_NAME
+          PYPROJECT_VERSION=$(sed -nE 's/^version\s*=\s*"([^"]+)"/\1/p' pyproject.toml)
+          echo "Tag version: $TAG_VERSION"
+          echo "pyproject.toml version: $PYPROJECT_VERSION"
+          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "Tag does not match pyproject.toml version."
+            exit 1
+          else
+            echo "Tag matches pyproject.toml version."
+          fi
+
+      - name: Verify tag points to latest main commit
+        run: |
+          git fetch origin main
+          LATEST_MAIN_SHA=$(git rev-parse origin/main)
+          echo "Tag commit SHA: $GITHUB_SHA"
+          echo "Latest main commit SHA: $LATEST_MAIN_SHA"
+          if [ "$GITHUB_SHA" != "$LATEST_MAIN_SHA" ]; then
+            echo "Tag does not point to the latest main commit."
+            exit 1
+          else
+            echo "Tag points to the latest main commit."
+          fi
+
+  check_pypi:
+    needs: verify_tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch information from PyPI
+        run: |
+          response=$(curl -s https://pypi.org/pypi/${{ env.PACKAGE_NAME }}/json || echo "{}")
+          latest_previous_version=$(echo $response | jq --raw-output "select(.releases != null) | .releases | keys_unsorted | last")
+          if [ -z "$latest_previous_version" ]; then
+            echo "Package not found on PyPI."
+            latest_previous_version="0.0.0"
+          fi
+          echo "Latest version on PyPI: $latest_previous_version"
+          echo "latest_previous_version=$latest_previous_version" >> $GITHUB_ENV
+
+      - name: Compare versions and exit if not newer
+        run: |
+          NEW_VERSION=$TAG_NAME
+          LATEST_VERSION=$latest_previous_version
+          HIGHEST_VERSION=$(printf '%s\n' "$LATEST_VERSION" "$NEW_VERSION" | sort -rV | head -n 1)
+          if [[ "$HIGHEST_VERSION" != "$NEW_VERSION" || "$NEW_VERSION" = "$LATEST_VERSION" ]]; then
+            echo "The new version $NEW_VERSION is not greater than the latest version $LATEST_VERSION on PyPI."
+            exit 1
+          else
+            echo "The new version $NEW_VERSION is greater than the latest version $LATEST_VERSION on PyPI."
+          fi
+
+  build:
+    needs: check_pypi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Upgrade pip and install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Install project package in editable mode
+        run: |
+          pip install -e .
+
+      - name: Build source and wheel distribution
+        run: |
+          python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  pypi_publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github_release:
+    needs: pypi_publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -1,0 +1,87 @@
+---
+name: Test Main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_container:
+          - version: "3.10"
+            image: "python:3.10-slim-bullseye"
+          - version: "3.11"
+            image: "python:3.11-slim-bullseye"
+          - version: "3.12"
+            image: "python:3.12-slim-bullseye"
+    container:
+      image: ${{ matrix.python_container.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ffmpeg
+        run: |
+          apt-get update && \
+          until apt-get install -y ffmpeg; do \
+            echo "Retrying ffmpeg installation..."; \
+            sleep 5; \
+          done
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --default-timeout=60 --retries=5 -r requirements-ci.txt
+
+      - name: Install project package in editable mode
+        run: |
+          pip install -e .
+
+      - name: Run unit tests
+        run: |
+          pytest --maxfail=2 --disable-warnings -m "not integration"
+
+  integration_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_container:
+          - version: "3.10"
+            image: "python:3.10-slim-bullseye"
+          - version: "3.11"
+            image: "python:3.11-slim-bullseye"
+          - version: "3.12"
+            image: "python:3.12-slim-bullseye"
+        test_type: [lti_integration, nonlinear_integration]
+    container:
+      image: ${{ matrix.python_container.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ffmpeg
+        run: |
+          apt-get update && \
+          until apt-get install -y ffmpeg; do \
+            echo "Retrying ffmpeg installation..."; \
+            sleep 5; \
+          done
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --default-timeout=60 --retries=5 -r requirements-ci.txt
+
+      - name: Install project package in editable mode
+        run: |
+          pip install -e .
+
+      - name: Run integration test - ${{ matrix.test_type }}
+        run: |
+          pytest --disable-warnings -m "${{ matrix.test_type }}"

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
     <th width="50%">Nonlinear Data-Driven MPC</th>
   </tr>
   <tr>
-    <td><img src="docs/resources/robust_dd_mpc_anim.gif" alt="Robust Data-Driven MPC Animation"></td>
-    <td><img src="docs/resources/nonlinear_dd_mpc_anim.gif" alt="Nonlinear Data-Driven MPC Animation"></td>
+    <td><img src="https://raw.githubusercontent.com/pavelacamposp/direct-data-driven-mpc/main/docs/resources/robust_dd_mpc_anim.gif" alt="Robust Data-Driven MPC Animation"></td>
+    <td><img src="https://raw.githubusercontent.com/pavelacamposp/direct-data-driven-mpc/main/docs/resources/nonlinear_dd_mpc_anim.gif" alt="Nonlinear Data-Driven MPC Animation"></td>
   </tr>
   <tr>
     <td>Robust controller applied to an LTI system.</td>
@@ -190,7 +190,7 @@ The figures below show the expected output from executing these scripts. The gra
 
 |LTI Data-Driven MPC|Nonlinear Data-Driven MPC|
 |-|-|
-|<img src="docs/resources/robust_dd_mpc_reproduction.png" alt="Robust Data-Driven MPC Animation">|<img src="docs/resources/nonlinear_dd_mpc_reproduction.png" alt="Nonlinear Data-Driven MPC Animation">|
+|<img src="https://raw.githubusercontent.com/pavelacamposp/direct-data-driven-mpc/main/docs/resources/robust_dd_mpc_reproduction.png" alt="Robust Data-Driven MPC Animation">|<img src="https://raw.githubusercontent.com/pavelacamposp/direct-data-driven-mpc/main/docs/resources/nonlinear_dd_mpc_reproduction.png" alt="Nonlinear Data-Driven MPC Animation">|
 |Reproduction of results from [[1]](#1)|Reproduction of results from [[2]](#2)|
 
 ## Code Structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-data-driven-mpc"
-version = "1.1"
+version = "1.1.0"
 authors = [
   { name = "Pável A. Campos-Peña", email = "pcamposp@uni.pe" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-data-driven-mpc"
-version = "1.1.0"
+version = "1.2.0"
 authors = [
   { name = "Pável A. Campos-Peña", email = "pcamposp@uni.pe" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ keywords = [
 ]
 classifiers = [
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Operating System :: OS Independent",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,0 @@
-numpy==2.3.1
-matplotlib==3.10.3
-clarabel==0.10.0
-cvxpy==1.6.6
-tqdm==4.67.1
-PyYAML==6.0.2
-PyQt6
-pre-commit
-mypy==1.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-numpy
-matplotlib>=3.9.0
-clarabel==0.10.0
-cvxpy
-tqdm
-PyYAML
-PyQt6


### PR DESCRIPTION
This PR adds a release workflow for automating package building, publishing to PyPI, and creating a GitHub release. It also adds a test workflow for testing the `main` branch across the supported Python versions of the project (`3.10`, `3.11`, `3.12`) to ensure compatibility and that the `main` branch is ready for release.

Additionally, it updates `README.md` to ensure it is correctly rendered on PyPI, removes unused requirements files to avoid redundancy with dependencies defined in `pyproject.toml`, and extends the Python classifiers list in `pyproject.toml` to align with the tested Python versions.

Bumped the project version to `1.2.0`.

### Key changes:
- Added release workflow `release.yml` for automating publishing to PyPI and releasing on GitHub.
- Added test workflow `test_main.yml` to test the `main` branch across the supported Python versions of the project.
- Updated `README.md` to use absolute URLs for media files to ensure it is correctly rendered in PyPI.
- Removed unused requirements files (`requirements.txt`, `requirements-dev.txt`) to avoid redundancy with dependencies defined in `pyproject.toml`.
- Extended Python classifiers in `pyproject.tom` to align with tested Python versions.
- Bumped project to `1.2.0`.
