### PR TITLE
Fix dependency installation issues in "Test Main" workflow

### DIFF
--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -34,10 +34,8 @@ jobs:
             sleep 5; \
           done
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --default-timeout=60 --retries=5 -r requirements-ci.txt
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
 
       - name: Install project package in editable mode
         run: |
@@ -73,10 +71,8 @@ jobs:
             sleep 5; \
           done
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --default-timeout=60 --retries=5 -r requirements-ci.txt
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
 
       - name: Install project package in editable mode
         run: |


### PR DESCRIPTION
This PR replaces the "Install dependencies" step in the `test_main.yml` workflow with the "Upgrade pip" step to avoid installing pinned dependencies from `requirements-ci.txt` across all test environments using different Python versions.

This prevents dependency installation errors like:
  `ERROR: No matching distribution found for numpy==2.3.1`

This way, the project will be installed in each container the same way it would normally be installed locally, which ensures correct testing of the main branch for release readiness.

### Key changes:
- Updated `test_main.yml` to install the project directly instead of installing pinned dependencies from `requirements-ci.txt`.