### PR TITLE
Fix missing pytest installation in Test Main workflow

### DIFF
--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -34,8 +34,10 @@ jobs:
             sleep 5; \
           done
 
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+      - name: Upgrade pip and install pytest
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
 
       - name: Install project package in editable mode
         run: |
@@ -71,8 +73,10 @@ jobs:
             sleep 5; \
           done
 
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+      - name: Upgrade pip and install pytest
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
 
       - name: Install project package in editable mode
         run: |


### PR DESCRIPTION
This PR updates the Test Main workflow to install pytest, which was mistakenly omitted. This ensures tests are correctly executed and fixes the error: `pytest: not found`.

### Key changes
- Updated `test_main.yml` to install pytest before executing tests.
